### PR TITLE
add truncval parameter to config

### DIFF
--- a/src/MonEl.pm
+++ b/src/MonEl.pm
@@ -452,6 +452,14 @@ $doc = {
 	  versn => '3.2',
       },
 
+      notify::truncval => {
+	  descr => 'truncate messageup/messagedn value to 40 characters',
+	  attrs => ['config', 'inherit'],
+	  versn => '3.7',
+	  default => 'yes',
+	  html  => 'notif',
+      },
+
       notify::list => {
 	  descr => 'list of all outstanding notifications',
       },

--- a/src/Notify.pm
+++ b/src/Notify.pm
@@ -697,7 +697,7 @@ sub expand {
 
     # pretify value
     my $v = $obj->{srvc} ? $obj->{srvc}{result} : undef;
-	if( length($v) > 40 && $me->{truncval} eq 'yes' ){
+    if( length($v) > 40 && $me->{truncval} eq 'yes' ){
 	$v = substr($v,0,40);
 	$v .= ' [...]';
     }

--- a/src/Notify.pm
+++ b/src/Notify.pm
@@ -89,6 +89,7 @@ sub new {
 	detail      => $param{detail},
 	severity    => $obj->{currseverity},
 	reason      => $obj->{srvc}{reason},
+	truncval    => $obj->{notify}{truncval},
     };
     bless $me; # gesundheit
 
@@ -696,7 +697,7 @@ sub expand {
 
     # pretify value
     my $v = $obj->{srvc} ? $obj->{srvc}{result} : undef;
-    if( length($v) > 40 ){
+	if( length($v) > 40 && $me->{truncval} eq 'yes' ){
 	$v = substr($v,0,40);
 	$v .= ' [...]';
     }

--- a/src/SSL.pm
+++ b/src/SSL.pm
@@ -139,7 +139,7 @@ sub writable {
     if( $me->{tcp}{wbuffer} ){
 	$me->debug( "SSL writing" );
 	my $ssl = $me->{tcp}{ssldata}{ssl};
-	my $i = Net::SSLeay::write( $ssl, $me->{tcp}{wbuffer} );
+	my $i = Net::SSLeay::ssl_write_CRLF( $ssl, $me->{tcp}{wbuffer} );
 	my $e = Net::SSLeay::ERR_get_error();
 	my $es = Net::SSLeay::ERR_error_string($e);
 	# $me->debug( "SSL wrote $i/$e" );


### PR DESCRIPTION
Argus normally truncates %v in messageup/dn to 40 characters and then appends " [...]".  This parameter adds the ability to not truncate.  default value is "yes" which keeps existing behavior.  set truncval: no in config to send non-truncated value.
